### PR TITLE
Support for gitlab-CI/CD pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ To convert 'report.checkstyle.xml' file to JSON and store the result in 'report.
 
 - `-B, --before BEFORE`  Amount of lines before used for file context fetch (default: 3)
 - `-A, --after AFTER`    Amount of lines after used for file context fetch (default: 3)
+- `-G, --gitlab`         Create a file suitable for the CI/CD-pipeline upload to gitlab.com
 
 ## JSON format
+
+### Standard
 
 ```
 {
@@ -42,3 +45,21 @@ To convert 'report.checkstyle.xml' file to JSON and store the result in 'report.
     ]
 }
 ```
+
+### GitLab format
+
+see https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool
+
+[
+  {
+    "description": "a description",
+    "fingerprint": "a checksum to (re-)identify issues",
+    "severity": "severity: info, minor, major, critical, or blocker",
+    "location": {
+      "path": "file/with_issue.R",
+      "lines": {
+        "begin": 42
+      }
+    }
+  }
+]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To convert 'report.checkstyle.xml' file to JSON and store the result in 'report.
 
 ### Standard
 
-```
+```json
 {
     "path/to/file": [
         {
@@ -50,6 +50,7 @@ To convert 'report.checkstyle.xml' file to JSON and store the result in 'report.
 
 see https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool
 
+```json
 [
   {
     "description": "a description",
@@ -63,3 +64,4 @@ see https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#imp
     }
   }
 ]
+```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ see https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#imp
     "fingerprint": "a checksum to (re-)identify issues",
     "severity": "severity: info, minor, major, critical, or blocker",
     "location": {
-      "path": "file/with_issue.R",
+      "path": "file/with_issue.java",
       "lines": {
         "begin": 42
       }

--- a/checkstyle-to-json.py
+++ b/checkstyle-to-json.py
@@ -67,9 +67,13 @@ for fileElement in ElementTree.parse(args.source).getroot():
           column = int(errorElement.attrib['column'])
         else:
           column = 0
+        if "source" in errorElement.attrib:
+          source = errorElement.attrib['source']
+        else:
+          source = ""
         items.append({
             'severity': errorElement.attrib['severity'],
-#            'source': errorElement.attrib['source'],
+            'source': source,
             'line': line,
             'column': column,
             'message': errorElement.attrib['message'],

--- a/checkstyle-to-json.py
+++ b/checkstyle-to-json.py
@@ -3,6 +3,7 @@
 import json
 import hashlib
 import sys
+import os
 from argparse import ArgumentParser, FileType
 from itertools import repeat
 from xml.etree import ElementTree
@@ -82,6 +83,7 @@ for fileElement in ElementTree.parse(args.source).getroot():
         
         # https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md
         if args.gitlab:
+            fp_rel = os.path.relpath(filepath)
             item = {
                 'severity': 'info',
                 'categories': 'Style',
@@ -90,7 +92,7 @@ for fileElement in ElementTree.parse(args.source).getroot():
                       before=args.before, after=args.after).values()) + '\n```\n'
                 },
                 'location': {
-                    'path': filepath,
+                    'path': fp_rel,
                     'lines': {
                         'begin': line,
                     },

--- a/checkstyle-to-json.py
+++ b/checkstyle-to-json.py
@@ -69,7 +69,7 @@ for fileElement in ElementTree.parse(args.source).getroot():
           column = 0
         items.append({
             'severity': errorElement.attrib['severity'],
-            'source': errorElement.attrib['source'],
+#            'source': errorElement.attrib['source'],
             'line': line,
             'column': column,
             'message': errorElement.attrib['message'],

--- a/checkstyle-to-json.py
+++ b/checkstyle-to-json.py
@@ -59,12 +59,19 @@ for fileElement in ElementTree.parse(args.source).getroot():
 
     # Iterate over all errors
     for errorElement in fileElement:
-        line = int(errorElement.attrib['line'])
+        if "line" in errorElement.attrib:
+          line = int(errorElement.attrib['line'])
+        else:
+          line = 0
+        if "column" in errorElement.attrib:
+          column = int(errorElement.attrib['column'])
+        else:
+          column = 0
         items.append({
             'severity': errorElement.attrib['severity'],
             'source': errorElement.attrib['source'],
             'line': line,
-            'column': errorElement.attrib['column'],
+            'column': column,
             'message': errorElement.attrib['message'],
             'context': get_context(filepath, line,
                 before=args.before, after=args.after),

--- a/checkstyle-to-json.py
+++ b/checkstyle-to-json.py
@@ -56,6 +56,7 @@ def get_context(filepath, n, before=3, after=3):
 
 # Gathered files data
 files = {}
+all_items = []
 
 # Iterate over all files
 for fileElement in ElementTree.parse(args.source).getroot():
@@ -113,8 +114,15 @@ for fileElement in ElementTree.parse(args.source).getroot():
                     before=args.before, after=args.after),
             })
     files[filepath] = items
+    all_items = all_items + items
 
-# Print gathered files in json format
-args.dest.write(
-    json.dumps(files, indent=4, sort_keys=False)
-)
+if args.gitlab:
+  # Print gathered files in json format
+  args.dest.write(
+      json.dumps(all_items, indent=4, sort_keys=False)
+  )
+else:
+  # Print gathered files in json format
+  args.dest.write(
+      json.dumps(files, indent=4, sort_keys=False)
+  )

--- a/checkstyle-to-json.py
+++ b/checkstyle-to-json.py
@@ -62,7 +62,7 @@ for fileElement in ElementTree.parse(args.source).getroot():
         line = int(errorElement.attrib['line'])
         items.append({
             'severity': errorElement.attrib['severity'],
-            'source': errorElement.attrib['source'],
+#            'source': errorElement.attrib['source'],
             'line': line,
             'column': errorElement.attrib['column'],
             'message': errorElement.attrib['message'],


### PR DESCRIPTION
For gitlab.com, a slightly different JSON format is required. I've added support for this JSON format (https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool) triggered by the new command line argument `-G` or `--gitlab` resp.

In our pipelines, this works, this works, so merge it, if you like. 